### PR TITLE
Add GitHub Actions CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: build
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    env:
+      FASTK_DEST_DIR: /tmp/bin
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install -y libbz2-dev libcurl4-gnutls-dev liblzma-dev
+      - run: gcc --version
+      - run: make
+      - run: mkdir -p "${FASTK_DEST_DIR}"
+      - run: make install DEST_DIR="${FASTK_DEST_DIR}"


### PR DESCRIPTION
Hi,
I created a PR to enable GitHub Actions CI for this repository. The CI log on my forked repository is [here](https://github.com/junaruga/FASTK/runs/8163996647?check_suite_focus=true).

For the libraries to build bundled htslib, I referred to the Debian package recipe file.
https://salsa.debian.org/med-team/htslib/-/blob/master/debian/control

I checked the CI on my forked repository.
https://github.com/junaruga/FASTK/actions/runs/2981840619

The `ubuntu-latest` means Ubuntu 20.04.4 right now.

## Examples

Here are some cases in other projects.

* hifiasm: https://github.com/chhylp123/hifiasm/blob/master/.github/workflows/ci.yaml
* minimap2: https://github.com/lh3/minimap2/blob/master/.github/workflows/ci.yaml
* bowtie2: https://github.com/BenLangmead/bowtie2/tree/master/.github/workflows
* ruby: https://github.com/ruby/ruby/tree/master/.github/workflows


